### PR TITLE
Prevent link highlight from stopping touch propagation

### DIFF
--- a/MFJLabel.m
+++ b/MFJLabel.m
@@ -401,4 +401,9 @@ NSString * const MFJLabelDateAttributeName        = @"MFJLabelDateAttributeName"
     return (attributes[MFJLabelLinkAttributeName] || attributes[MFJLabelPhoneNumberAttributeName] || attributes[MFJLabelAddressAttributeName] || attributes[MFJLabelDateAttributeName]);
 }
 
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  return YES;
+}
+
 @end


### PR DESCRIPTION
Allow the link highlight gesture recognizer to live along side scroll
gesture recognizers, this will allow the link to get highlighted without
canceling scrolling.
